### PR TITLE
ci: add github actions configuration

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,0 +1,63 @@
+name: Lint, Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: 3.10
+  POETRY_VERSION: 1.6.1
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Load cached venv if cache exists
+        id: cached-poetry-dependencies
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies if cache does not exist
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+
+      - name: Install project
+        run: poetry install --no-interaction
+
+      - name: Verify code formatting (Black)
+        run: poetry run black --check --diff .
+
+      - name: Enforce code style (flake8)
+        continue-on-error: true
+        run: poetry run flake8 --show-source .
+
+      - name: Run tests
+        run: poetry run pytest --verbose

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -12,8 +12,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: 3.10
-  POETRY_VERSION: 1.6.1
+  PYTHON_VERSION: "3.10"
+  POETRY_VERSION: "1.6.1"
 
 jobs:
   lint-and-test:

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -2,7 +2,6 @@ name: Lint, Test
 
 on:
   push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
Summary:
- cf076cc93623408443798c6c37485807f90db677:
    - `.github/workflows/actions.yaml`: setup `github actions` with `black`, `flake8` and `tests`
- 2a8c7021fa9a600a572c86669141e2b2a227f6ee:
    - `.github/workflows/actions.yaml`: let `python` and `poetry` versions be environment variables of `string` type to fix the issue described in https://github.com/actions/setup-python/issues/401#issuecomment-1848265537
- cf076cc93623408443798c6c37485807f90db677:
    - `.github/workflows/actions.yaml`: modify the configuration file to trigger `actions` on push to any branch (notice that even in the previous configuration actions would have been triggered as a consequence of pushing a commit on an open PR)
