### PR TITLE
refactor: adopt ruff as a linter

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -51,12 +51,11 @@ jobs:
       - name: Install project
         run: poetry install --no-interaction
 
+      - name: Enforce code style (Ruff)
+        run: poetry run ruff check --show-source --show-fixes .
+
       - name: Verify code formatting (Black)
         run: poetry run black --check --diff .
-
-      - name: Enforce code style (flake8)
-        continue-on-error: true
-        run: poetry run flake8 --show-source .
 
       - name: Run tests
         run: poetry run pytest --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 .mypy_cache/
 .coverage
 coverage.xml
+.ruff_cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,13 +11,14 @@ repos:
       - id: check-toml
   - repo: local
     hooks:
+      - id: ruff
+        name: ruff (linter)
+        entry: poetry run ruff check .
+        language: system
+        types: [python]
+        args: [--fix]
       - id: black
         name: black
         entry: poetry run black .
-        language: system
-        types: [python]
-      - id: flake8
-        name: flake8
-        entry: poetry run flake8 .
         language: system
         types: [python]

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Personal attempt to solve the `advent-of-code`[^aoc] puzzles in a `TDD` fashion 
 
 ### ⚠️ TODO:
  - Repo setup:
-   - 🚧 try out `ruff` as a linter, thus replacing `flake8`
+   - 🚧 ~~try out `ruff` as a linter, thus replacing `flake8`~~
    - 🚧 rely on a unique configuration file (possibly `pyproject.toml`)
    - 🚧 add `mypy` (`--strict`?) in the pipeline
-   - 🚧 try out `ruff` as a formatter, thus replacing `black`?
    - 🚧 `makefile` | `justfile`
+   - 🚧 try out `ruff` as a formatter, thus replacing `black`?
    - 🚧 Dockerization?
    - 🚧 else?
  - Puzzles:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Personal attempt to solve the `advent-of-code`[^aoc] puzzles in a `TDD` fashion 
    - 🚧 try out `ruff` as a linter, thus replacing `flake8`
    - 🚧 rely on a unique configuration file (possibly `pyproject.toml`)
    - 🚧 add `mypy` (`--strict`?) in the pipeline
+   - 🚧 try out `ruff` as a formatter, thus replacing `black`?
    - 🚧 `makefile` | `justfile`
    - 🚧 Dockerization?
    - 🚧 else?

--- a/poetry.lock
+++ b/poetry.lock
@@ -506,6 +506,32 @@ files = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.1.11"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.1.11-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:a7f772696b4cdc0a3b2e527fc3c7ccc41cdcb98f5c80fdd4f2b8c50eb1458196"},
+    {file = "ruff-0.1.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:934832f6ed9b34a7d5feea58972635c2039c7a3b434fe5ba2ce015064cb6e955"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea0d3e950e394c4b332bcdd112aa566010a9f9c95814844a7468325290aabfd9"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9bd4025b9c5b429a48280785a2b71d479798a69f5c2919e7d274c5f4b32c3607"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1ad00662305dcb1e987f5ec214d31f7d6a062cae3e74c1cbccef15afd96611d"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:4b077ce83f47dd6bea1991af08b140e8b8339f0ba8cb9b7a484c30ebab18a23f"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4a88efecec23c37b11076fe676e15c6cdb1271a38f2b415e381e87fe4517f18"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5b25093dad3b055667730a9b491129c42d45e11cdb7043b702e97125bcec48a1"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:231d8fb11b2cc7c0366a326a66dafc6ad449d7fcdbc268497ee47e1334f66f77"},
+    {file = "ruff-0.1.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:09c415716884950080921dd6237767e52e227e397e2008e2bed410117679975b"},
+    {file = "ruff-0.1.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0f58948c6d212a6b8d41cd59e349751018797ce1727f961c2fa755ad6208ba45"},
+    {file = "ruff-0.1.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:190a566c8f766c37074d99640cd9ca3da11d8deae2deae7c9505e68a4a30f740"},
+    {file = "ruff-0.1.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6464289bd67b2344d2a5d9158d5eb81025258f169e69a46b741b396ffb0cda95"},
+    {file = "ruff-0.1.11-py3-none-win32.whl", hash = "sha256:9b8f397902f92bc2e70fb6bebfa2139008dc72ae5177e66c383fa5426cb0bf2c"},
+    {file = "ruff-0.1.11-py3-none-win_amd64.whl", hash = "sha256:eb85ee287b11f901037a6683b2374bb0ec82928c5cbc984f575d0437979c521a"},
+    {file = "ruff-0.1.11-py3-none-win_arm64.whl", hash = "sha256:97ce4d752f964ba559c7023a86e5f8e97f026d511e48013987623915431c7ea9"},
+    {file = "ruff-0.1.11.tar.gz", hash = "sha256:f9d4d88cb6eeb4dfe20f9f0519bd2eaba8119bde87c3d5065c541dbae2b5a2cb"},
+]
+
+[[package]]
 name = "setuptools"
 version = "69.0.3"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -566,4 +592,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "73dbd3573a086756cc11ead6107ba31526cdafb7699d4827af3a87984d6ef990"
+content-hash = "f6f25af2d84c6b11014c669ba7b8e1394ab7653e713db71720b8e7f055692c32"

--- a/poetry.lock
+++ b/poetry.lock
@@ -191,22 +191,6 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8)", "pyt
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
-name = "flake8"
-version = "6.1.0"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = ">=3.8.1"
-files = [
-    {file = "flake8-6.1.0-py2.py3-none-any.whl", hash = "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"},
-    {file = "flake8-6.1.0.tar.gz", hash = "sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.11.0,<2.12.0"
-pyflakes = ">=3.1.0,<3.2.0"
-
-[[package]]
 name = "identify"
 version = "2.5.33"
 description = "File identification library for Python"
@@ -229,17 +213,6 @@ python-versions = ">=3.7"
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
-]
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
 
 [[package]]
@@ -383,28 +356,6 @@ identify = ">=1.0.0"
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
-
-[[package]]
-name = "pycodestyle"
-version = "2.11.1"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67"},
-    {file = "pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f"},
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.1.0"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pyflakes-3.1.0-py2.py3-none-any.whl", hash = "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774"},
-    {file = "pyflakes-3.1.0.tar.gz", hash = "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc"},
-]
 
 [[package]]
 name = "pytest"
@@ -592,4 +543,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "f6f25af2d84c6b11014c669ba7b8e1394ab7653e713db71720b8e7f055692c32"
+content-hash = "fa2eb4ff560518f1077f54cd79e3c3e94e1be4b85baba4ec5cd2ab67567198da"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ flake8 = "^6.1.0"
 mypy = "^1.8.0"
 coverage = "^7.4.0"
 pytest-cov = "^4.1.0"
+ruff = "^0.1.11"
 
 [build-system]
 requires = ["poetry-core"]
@@ -27,3 +28,66 @@ build-backend = "poetry.core.masonry.api"
 line-length = 100
 target-version = ["py310"]
 preview = true
+
+[tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+line-length = 100
+indent-width = 4
+target-version = "py310"
+show-source = true
+show-fixes = true
+
+[tool.ruff.lint]
+select = [
+  # default
+  "E",      # pycodestyle error
+  "F",      # flake8 error
+  # extra
+  "A",      # builtin shadowing
+  "B",      # flake8 bugbear
+  "BLE",    # avoid bare excepts
+  "C4",     # simplify comprehensions
+  "DTZ",    # datetime errors
+  "FBT",    # avoid boolean trap
+  "G",      # logging format
+  "I",      # isort imports
+  "N",      # conform to PEP8 naming rules
+  "RET",    # return values
+  "S",      # bandit
+  "TRY",    # exceptions antipatterns
+  "UP",     # upgrade syntax
+  "W",      # pycodestyle warning
+  "YTT",    # wrong usage of sys.info
+]
+fixable = ["ALL"]
+
+[tool.ruff.lint.per-file-ignores]
+"test*.py" = ["S101"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ python = "^3.10"
 pytest = "^7.4.3"
 pre-commit = "^3.6.0"
 black = "^23.12.1"
-flake8 = "^6.1.0"
 mypy = "^1.8.0"
 coverage = "^7.4.0"
 pytest-cov = "^4.1.0"
@@ -87,7 +86,6 @@ select = [
   "W",      # pycodestyle warning
   "YTT",    # wrong usage of sys.info
 ]
-fixable = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
 "test*.py" = ["S101"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
-[flake8]
-max-line-length = 100
-extend-ignore = E203, W503
-filename =
-    ./src/*.py,
-    ./tests/*.py
+# [flake8]
+# max-line-length = 100
+# extend-ignore = E203, W503
+# filename =
+#     ./src/*.py,
+#     ./tests/*.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-# [flake8]
-# max-line-length = 100
-# extend-ignore = E203, W503
-# filename =
-#     ./src/*.py,
-#     ./tests/*.py

--- a/src/year_2023/day02/part1.py
+++ b/src/year_2023/day02/part1.py
@@ -18,6 +18,7 @@ def get_ncubes_combination_per_game(input_str: str) -> list[tuple[int]]:
             get_ncubes_by_colour_per_game(input_str, "red"),
             get_ncubes_by_colour_per_game(input_str, "green"),
             get_ncubes_by_colour_per_game(input_str, "blue"),
+            strict=False,
         )
     )
 
@@ -31,10 +32,11 @@ def sum_feasible_games_ids(file_path: str) -> int:
         int(re.search(r"\d+(?=:)", line).group())
         for line in lines
         if all(
-            all(el1 <= el2 for el1, el2 in zip(combination, target))
+            all(el1 <= el2 for el1, el2 in zip(combination, target, strict=False))
             for combination, target in zip(
                 get_ncubes_combination_per_game(line),
                 [(12, 13, 14)] * len(get_ncubes_combination_per_game(line)),
+                strict=False,
             )
         )
     )

--- a/src/year_2023/day02/part2.py
+++ b/src/year_2023/day02/part2.py
@@ -1,5 +1,4 @@
 import os
-
 from functools import reduce
 from operator import mul
 
@@ -8,7 +7,7 @@ from src.year_2023.utils import read_file
 
 
 def get_min_ncubes_to_play(input_str: str) -> list[int]:
-    return [max(cube) for cube in zip(*get_ncubes_combination_per_game(input_str))]
+    return [max(cube) for cube in zip(*get_ncubes_combination_per_game(input_str), strict=False)]
 
 
 def sum_power_ncubes(file_path: str) -> int:

--- a/src/year_2023/day03/part1.py
+++ b/src/year_2023/day03/part1.py
@@ -29,12 +29,10 @@ def get_symbols_pos(input_lines: list[str]) -> list[int]:
 def get_candidate_pnum_symbols_pos(number_pos: tuple[int], len_input: int) -> list[int]:
     num_p_start, num_p_end, _ = number_pos
     return sorted(
-        list(
-            set(range(num_p_start - len_input - 1, num_p_end - len_input + 1))
-            .union(set(range(num_p_start - 1, num_p_start)))
-            .union(set(range(num_p_end, num_p_end + 1)))
-            .union(set(range(num_p_start + len_input - 1, num_p_end + len_input + 1)))
-        )
+        set(range(num_p_start - len_input - 1, num_p_end - len_input + 1))
+        .union(set(range(num_p_start - 1, num_p_start)))
+        .union(set(range(num_p_end, num_p_end + 1)))
+        .union(set(range(num_p_start + len_input - 1, num_p_end + len_input + 1)))
     )
 
 
@@ -43,16 +41,16 @@ def sum_part_numbers(file_path: str) -> int:
     len_input = get_len_input(input_lines)
     numbers_pos = get_numbers_pos(input_lines)
     symbols_pos = get_symbols_pos(input_lines)
-    sum = 0
+    result = 0
     for num_p_start, num_p_end, num in numbers_pos:
         candidate_symbols_pos = get_candidate_pnum_symbols_pos(
             (num_p_start, num_p_end, num), len_input
         )
         for sym_p_start in symbols_pos:
             if sym_p_start in candidate_symbols_pos:
-                sum += num
+                result += num
                 break
-    return sum
+    return result
 
 
 if __name__ == "__main__":

--- a/src/year_2023/day06/part1.py
+++ b/src/year_2023/day06/part1.py
@@ -1,7 +1,6 @@
 import os
 import re
 import typing
-
 from functools import reduce
 
 from src.year_2023.utils import read_file
@@ -10,7 +9,7 @@ from src.year_2023.utils import read_file
 def get_time_and_winning_distance_per_race(lines: list[str]) -> typing.Iterator:
     times = [int(num) for num in re.findall(r"\b\d+", lines[0])]
     distances = [int(num) for num in re.findall(r"\b\d+", lines[1])]
-    return zip(times, distances)
+    return zip(times, distances, strict=False)
 
 
 def get_n_winning_combinations(time: int, distance: int) -> int:

--- a/src/year_2023/day06/part2.py
+++ b/src/year_2023/day06/part2.py
@@ -1,8 +1,8 @@
 import os
 import re
 
-from src.year_2023.utils import read_file
 from src.year_2023.day06.part1 import get_n_winning_combinations as _get_n_winning_combinations
+from src.year_2023.utils import read_file
 
 
 def get_time_and_winning_distance(lines: list[str]) -> tuple[int]:

--- a/src/year_2023/day07/part1.py
+++ b/src/year_2023/day07/part1.py
@@ -1,9 +1,7 @@
 import os
-
 from collections import Counter
 
 from src.year_2023.utils import read_file
-
 
 camel_cards_p1 = ["2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K", "A"]
 
@@ -51,7 +49,7 @@ def _map_ladder_to_rank(ladder: list[int]) -> int:
 def get_sorted_hand_values_by_rank(
     ladders: list[list[int]], hands_to_values: list[list[int]]
 ) -> list[tuple[list[int]]]:
-    ladders_and_values = list(zip(ladders, hands_to_values))
+    ladders_and_values = list(zip(ladders, hands_to_values, strict=False))
     return sorted(
         ladders_and_values, key=lambda x: (-_map_ladder_to_rank(x[0]), tuple(-el for el in x[1]))
     )
@@ -67,7 +65,7 @@ def get_hands_to_rank(lines: list[str], camel_cards: list[str]) -> dict[str, int
     ]
     return {
         map_values_to_hand(hand_values, camel_cards): rank
-        for (_, hand_values), rank in zip(sorted_hand_values, hand_values_rank)
+        for (_, hand_values), rank in zip(sorted_hand_values, hand_values_rank, strict=False)
     }
 
 

--- a/src/year_2023/day07/part2.py
+++ b/src/year_2023/day07/part2.py
@@ -1,5 +1,4 @@
 import os
-
 from collections import Counter
 
 from src.year_2023.day07.part1 import (
@@ -10,7 +9,6 @@ from src.year_2023.day07.part1 import (
     map_values_to_hand,
 )
 from src.year_2023.utils import read_file
-
 
 camel_cards_p2 = ["J", "2", "3", "4", "5", "6", "7", "8", "9", "T", "Q", "K", "A"]
 
@@ -44,7 +42,7 @@ def get_hands_to_rank(lines: list[str], camel_cards: list[int]) -> dict[str, int
     ]
     return {
         map_values_to_hand(hand_values, camel_cards): rank
-        for (_, hand_values), rank in zip(sorted_hand_values, hand_values_rank)
+        for (_, hand_values), rank in zip(sorted_hand_values, hand_values_rank, strict=False)
     }
 
 

--- a/src/year_2023/utils.py
+++ b/src/year_2023/utils.py
@@ -1,3 +1,3 @@
 def read_file(file_path: str) -> list[str]:
-    with open(file_path, "r") as file:
+    with open(file_path) as file:
         return list(file.read().split("\n"))

--- a/tests/year_2023/day07/test_day07_part1.py
+++ b/tests/year_2023/day07/test_day07_part1.py
@@ -8,8 +8,8 @@ from src.year_2023.day07.part1 import (
     get_hands_to_rank,
     get_sorted_hand_values_by_rank,
     get_total_winnings,
-    map_hand_to_values,
     map_hand_to_ladder,
+    map_hand_to_values,
     map_values_to_hand,
 )
 from src.year_2023.utils import read_file


### PR DESCRIPTION
Summary:
- c0179d3f4fc28e24fddedf52054f534d0c61308e:
    - `pyproject.toml`: add configuration for `ruff` linter [^notes_ruff_config_1] [^notes_ruff_config_2]
    - `.pre-commit-config.yaml`: add `pre-commit` hook for `ruff` (while removing `flake8`'s one) [^notes_pre_commit]
    - `.github/workflows/actions.yaml`: setup _action_ for `ruff` linter (while removing `flake8`'s one)
    - leftover: apply `ruff` and `black` proposed fixes
- f785b9eeb050bf87d675a1ae9ddda210d356371c:
    - `poetry.lock`, `pyproject.toml`, `setup.cfg`: remove `flake8` dependency
    - `pyproject.toml`: `fixable = ["ALL"]` is redundant [^fixable_all_ruff]
    - `README.md`: update `README` as a consequence of enforcing the use of `ruff` over `flake8`


[^notes_ruff_config_1]: better nest _linter-specific_ configs under `[tool.ruff.lint]`, _formatter-specific_ configs under `[tool.ruff.format]` and configs common to both linter and formatter under `[tool.ruff]` (see https://github.com/astral-sh/ruff/discussions/9406)
[^notes_ruff_config_2]: note that
    - `ruff`'s autofix feature is available for most of the lint rules, but not for all of them (eg an autofix for `A001` is not available, as I could experience); list of available autofixes at https://docs.astral.sh/ruff/linter/#fix-safety
    - `ruff`'s autofix feature does not apply to _unsafe fixes_ (eg `C414`, as I could experience); you'd need to promote unsafe fixes to safe by specifying eg `extend-safe-fixes = ["C414"]` under `[tool.ruff.lint]` (see https://docs.astral.sh/ruff/linter/#fix-safety) or proceed manually
[^notes_pre_commit]: be aware of putting `ruff`'s linter hook _before_ any formatter hook (`black` here) as `ruff`'s `--fix` might apply changes requiring reformatting, which indeed happened (see https://docs.astral.sh/ruff/integrations/#pre-commit)
[^fixable_all_ruff]: `fixable = ["ALL"]` is the default already. Better configure such option in order to specify the (sub)-list of _selected_ (i.e. specified in `select =`) rules that you would not only _check_ against but also _autofix_ (provided that an autofix is available for them and is _safe_); indeed, there might be rules you would check against, but _manually_ (and not automatically) fix