### PR TITLE
chore: update ruff configs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ select = [
   "W",      # pycodestyle warning
   "YTT",    # wrong usage of sys.info
 ]
+ignore = ["E501"]
 
 [tool.ruff.lint.per-file-ignores]
 "test*.py" = ["S101"]


### PR DESCRIPTION
Summary:
- 2fe2ffa0415358cea8afbc0614125e753273bd84:
    - `pyproject.toml`: ignore `line-too-long` (`E501`) rule; (in the spirit of `ruff`) it is not very convenient to enforce `E501` rule while using `black` (or `ruff`) as a formatter [^e501_side_note] as `black` itself will try to autoformat lines according to the `line-length` setting where possible; there might be situations where autoformatting is not possible and in such cases enforcing `E501` will result in linting errors (unless a `# noqa` specification is there)


[^e501_side_note]: indeed notice that, if I were to use `ruff`'s default `select`ion setting, `E501` rule would be omitted as consequence of overlapping with the use of the formatter (see https://docs.astral.sh/ruff/tutorial/#configuration). By default, `ruff` enables `F` rules (`flake8` compliant) and a _subset_ of `E` rules (among which you won't find `E501`), namely those stylistic rules that do not overlap with the use of a formatter (like `black` or `ruff` formatter itself)
See also https://docs.astral.sh/ruff/faq/#is-the-ruff-linter-compatible-with-black: 
    > Ruff is designed to be used alongside a formatter (like Ruff's own formatter, or Black) and, as such, _**will defer implementing stylistic rules that are obviated by automated formatting**_.