### PR TITLE
feat: add justfile, update pre-commit and github actions configs accordingly

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash
+        shell: pwsh
 
     steps:
       - name: Check out repository

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: pwsh
+        shell: bash
 
     steps:
       - name: Check out repository
@@ -53,23 +53,17 @@ jobs:
 
       - name: Setup just
         uses: taiki-e/install-action@just
-        with:
-          shell: pwsh
 
       - name: Enforce code style (Ruff)
-        shell: pwsh
         run: just ruff-show-violations
 
       - name: Verify code formatting (Black)
-        shell: pwsh
         run: just black-check
 
       - name: Run tests
-        shell: pwsh
         run: just test
 
       - name: Generate test coverage report
-        shell: pwsh
         run: just test-and-report-cov
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -57,24 +57,20 @@ jobs:
           shell: pwsh
 
       - name: Enforce code style (Ruff)
+        shell: pwsh
         run: just ruff-show-violations
-        with:
-          shell: pwsh
 
       - name: Verify code formatting (Black)
+        shell: pwsh
         run: just black-check
-        with:
-          shell: pwsh
 
       - name: Run tests
+        shell: pwsh
         run: just test
-        with:
-          shell: pwsh
 
       - name: Generate test coverage report
+        shell: pwsh
         run: just test-and-report-cov
-        with:
-          shell: pwsh
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: pwsh
+        shell: powershell
 
     steps:
       - name: Check out repository

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: powershell
+        shell: pwsh
 
     steps:
       - name: Check out repository
@@ -53,18 +53,28 @@ jobs:
 
       - name: Setup just
         uses: taiki-e/install-action@just
+        with:
+          shell: pwsh
 
       - name: Enforce code style (Ruff)
         run: just ruff-show-violations
+        with:
+          shell: pwsh
 
       - name: Verify code formatting (Black)
         run: just black-check
+        with:
+          shell: pwsh
 
       - name: Run tests
         run: just test
+        with:
+          shell: pwsh
 
       - name: Generate test coverage report
         run: just test-and-report-cov
+        with:
+          shell: pwsh
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -52,16 +52,16 @@ jobs:
         run: poetry install --no-interaction
 
       - name: Enforce code style (Ruff)
-        run: poetry run ruff check --show-source --show-fixes .
+        run: just ruff-show-violations
 
       - name: Verify code formatting (Black)
-        run: poetry run black --check --diff .
+        run: just black-check
 
       - name: Run tests
-        run: poetry run pytest --verbose
+        run: just test
 
       - name: Generate test coverage report
-        run: poetry run pytest --cov=./ --cov-report=xml
+        run: just test-and-report-cov
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -51,6 +51,9 @@ jobs:
       - name: Install project
         run: poetry install --no-interaction
 
+      - name: Setup just
+        uses: taiki-e/install-action@just
+
       - name: Enforce code style (Ruff)
         run: just ruff-show-violations
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,12 +13,12 @@ repos:
     hooks:
       - id: ruff
         name: ruff (linter)
-        entry: poetry run ruff check .
+        entry: just ruff
         language: system
         types: [python]
         args: [--fix]
       - id: black
         name: black
-        entry: poetry run black .
+        entry: just black
         language: system
         types: [python]

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Personal attempt to solve the `advent-of-code`[^aoc] puzzles in a `TDD` fashion 
 ### ⚠️ TODO:
  - Repo setup:
    - 🚧 ~~try out `ruff` as a linter, thus replacing `flake8`~~
+   - 🚧 ~~`makefile` | `justfile`~~
    - 🚧 rely on a unique configuration file (possibly `pyproject.toml`)
    - 🚧 add `mypy` (`--strict`?) in the pipeline
-   - 🚧 `makefile` | `justfile`
    - 🚧 try out `ruff` as a formatter, thus replacing `black`?
    - 🚧 Dockerization?
    - 🚧 else?

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 # Use PowerShell instead of sh
-set shell := ["powershell.exe", "-c"]
+# set shell := ["powershell.exe", "-c"]
 
 help:
   @just --list

--- a/justfile
+++ b/justfile
@@ -1,0 +1,49 @@
+# Use PowerShell instead of sh
+set shell := ["powershell.exe", "-c"]
+
+help:
+  @just --list
+
+install:
+  @echo "🚀 Installing dependencies"
+  @poetry install --with dev
+
+install-pre-commit:
+  @echo "🚀 Setting up the hooks"
+  @poetry run pre-commit install
+
+check-project:
+  @echo "🚀 Checking consistency between poetry.lock and pyproject.toml"
+  @poetry check --lock
+  @echo "🚀 Running the hooks against all files"
+  @poetry run pre-commit run --all-files
+
+ruff:
+  @echo "🚀 Linting the project with Ruff"
+  @poetry run ruff check src tests
+
+ruff-show-violations:
+  @echo "🚀 Linting the project with Ruff and show violations"
+  @poetry run ruff check --show-source --show-fixes src tests
+
+ruff-fix:
+  @echo "🚀 Linting the project with Ruff and autofix violations (where possible)"
+  @poetry run ruff check --fix src tests
+
+black:
+  @echo "🚀 Formatting the code with Black"
+  @poetry run black src tests
+
+black-check:
+  @echo "🚀 Checking formatting advices from Black"
+  @poetry run black --check --diff src tests
+
+lint-and-format: ruff black
+
+test:
+  @echo "🚀 Testing code with pytest"
+  @poetry run pytest --verbose tests
+
+test-and-report-cov:
+  @echo "🚀 Testing code with pytest and generating coverage report"
+  @poetry run pytest --cov=./ --cov-report=xml


### PR DESCRIPTION
Summary:
- 150c5f00ea2ba602d1809bc0503a8084d126ddd2:
    - `justfile`: add `justfile`, a collector of `just` commands; [`just`](https://just.systems/man/en/) is a command runner alternative to `make`
    - `.pre-commit-config.yaml`: run (relevant) `pre-commit` hooks with `just`
    - `.github/workflows/actions.yaml`: run (relevant) CI steps with `just`
- 00b17547f91cf375343ec08dd1286401b8687d11:
    - `README.md`: update `README`
- c28d678353457def41bcda2ecc1e861e7b488d13:
    - `.github/workflows/actions.yaml`: setup `taiki-e/install-action@just` action to install `just` within the CI pipeline (necessary step to be able to invoke `just` commands there)
- 1fbcfd21c93850ee2e30ab05f3400c52f7d1c4e8, d57c86b78b765701c13ff2eb783803c86c5b2d12, 8af1f04ff1918eb1c706a677401b45ad8ffa2712, 6c1bcf1693f83aef16fbbd47691411e9aa2fae85:
    - `.github/workflows/actions.yaml`: failed attempts to make `just` commands run on `powershell` within the CI pipeline [^pwsh_config]. Further references:
        - https://stackoverflow.com/questions/77835519/just-command-alias-could-not-be-run-because-just-could-not-find-the-shell
        - https://github.com/casey/just/discussions/1852
- e4bf404999d4aedad1d870395ef2cbe9eaf16a99:
    - `.github/workflows/actions.yaml`: run actions on `bash` (default)
    - `justfile`: remove `powershell` configuration to revert to (default) `bash` [^bash_config]


[^pwsh_config]: I would have liked to be able to invoke `just` commands on `powershell` (both locally and within the CI pipeline) for personal preference; while managing to make it work locally (being it sufficient to specify `set shell := ["powershell.exe", "-c"]` within the `justfile` as per [the docs](https://just.systems/man/en/chapter_3.html)), I encountered some issues in making it work within the CI pipeline. My understanding is that:
    - given that the CI (Github Actions) workflow (typically) runs in a Linux environment, `bash` is the default shell there
    - when specifying `powershell.exe` as the shell in `justfile`, potential compatibility issues might arise as you try to use `powershell` syntax in `bash`
    - therefore, you should ensure alignment between the execution environment and the (typical) Linux environment in Github Actions.

    This said, my attempts to setup the CI steps so that they could run on `powershell` miserably failed:
    - specifying `powershell` to be the default shell at _job_ level in `actions.yaml` didn't work
    - specifying each (relevant) _step_ to be run on `powershell` didn't work
    - no matter what the default shell configuration was, `taiki-e/install-action@just` kept on running on `bash` (with no possibility to specify a `with: shell:` configuration)

    _Need to explore it further!_

[^bash_config]: I ended up running `just` commands on `bash` (both locally and in the CI pipeline).