### PR TITLE
chore: refine just commands

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,9 @@ repos:
     hooks:
       - id: ruff
         name: ruff (linter)
-        entry: just ruff
+        entry: just ruff-fix
         language: system
         types: [python]
-        args: [--fix]
       - id: black
         name: black
         entry: just black

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ ruff:
 
 ruff-show-violations:
   @echo "🚀 Linting the project with Ruff and show violations"
-  @poetry run ruff check --show-source --show-fixes src tests
+  @poetry run ruff check --show-source src tests
 
 ruff-fix:
   @echo "🚀 Linting the project with Ruff and autofix violations (where possible)"
@@ -35,10 +35,14 @@ black:
   @poetry run black src tests
 
 black-check:
-  @echo "🚀 Checking formatting advices from Black"
-  @poetry run black --check --diff src tests
+  @echo "🚀 Listing files Black would reformat"
+  @poetry run black --check src tests
 
-lint-and-format: ruff black
+black-diff:
+  @echo "🚀 Checking formatting advices from Black"
+  @poetry run black --diff src tests
+
+lint-and-format: ruff-fix black
 
 test:
   @echo "🚀 Testing code with pytest"


### PR DESCRIPTION
Summary:
- 665873d85871c4814233454bfe301cc0ac567984:
    - `justfile`: refine `just` commands; distinguish `--check` from `--diff` as `black` options
    - `justfile`: `ruff`'s `--show-fixes` lists all fixed lint violations (it has no sense without `--fix`)
    - `.pre-commit-config.yaml`: `ruff-fix` `just`'s command already accounts for `--fix`